### PR TITLE
Fix NativeEventEmitter warning on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 import {
   NativeModules,
   NativeEventEmitter,
+  Platform
 } from 'react-native';
 
 const { RNHeadphoneDetection } = NativeModules;
-const eventEmitter = new NativeEventEmitter(RNHeadphoneDetection);
+const eventEmitter = new NativeEventEmitter(Platform.OS == "android" ? null : RNHeadphoneDetection);
 
 export default {
   ...RNHeadphoneDetection,


### PR DESCRIPTION
On Android, I'm getting the following warnings from this library:
 
```
WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
```

I was able to resolve this by following the suggestion found here:

https://stackoverflow.com/a/70283349/1060679

Everything is working great after making this change and I'm no longer getting these warnings.